### PR TITLE
[fix] fix-init-db init.goの修正

### DIFF
--- a/fixtures/init.go
+++ b/fixtures/init.go
@@ -54,7 +54,9 @@ func main() {
 	}
 
 	util.LoadEnv()
-	mysqlConnectionString := infra.NewMySQLConnectionOptionsWithENV().String()
+	mysqlConn := infra.NewMySQLConnectionOptionsWithENV()
+	mysqlConn.Database = ""
+	mysqlConnectionString := mysqlConn.String()
 	fmt.Println(mysqlConnectionString)
 
 	err := runSource(mysqlConnectionString, os.Args[1])


### PR DESCRIPTION
`sh ./fixtures/init_db.sh`コマンドで起きるエラーの修正です。